### PR TITLE
Add experiment ramp information (async) + improve caching + extension…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -518,6 +518,14 @@
       "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://artifacts-prod-use1.pinadmin.com/artifactory/api/npm/node-npm-yarn-prod-virtual/acorn/-/acorn-7.4.1.tgz",
@@ -1280,6 +1288,11 @@
       "resolved": "https://artifacts-prod-use1.pinadmin.com/artifactory/api/npm/node-npm-yarn-prod-virtual/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "events": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "webpack-cli": "^4.2.0"
   },
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "fuse.js": "^6.4.4",
     "got": "^11.8.1",
     "node-fetch": "^2.6.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,11 +43,10 @@ export function addDeciderExperimentProviders(): Disposable {
 // your extension is activated the very first time the command is executed
 export async function activate(context: ExtensionContext) {
   log.append('Extension "vscode-pinterest" is active');
-  log.show();
 
   extensionContext.set(context);
 
-  await cache.update();
+  cache.update();
   const updateCacheDisposable = commands.registerCommand(
     "vscode-pinterest.updateCache",
     async () => {
@@ -55,9 +54,9 @@ export async function activate(context: ExtensionContext) {
     }
   );
 
-  // setInterval(async () => {
-  //   await cache.update();
-  // }, 10000);
+  setInterval(async () => {
+    await cache.update();
+  }, 10000);
 
   context.subscriptions.push(updateCacheDisposable);
 


### PR DESCRIPTION
* Cache now persists across VSCode start-ups
* Async fetch the experiment ramp information (was tricky to get from MySQL because the data type of group ranges is Python's PickleType)
* Extension now doesn't wait for an initial fetch